### PR TITLE
Roll conscrpyt back to 1.4.1 for Centos:6 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2363,7 +2363,7 @@
       <dependency>
         <groupId>org.conscrypt</groupId>
         <artifactId>conscrypt-openjdk-uber</artifactId>
-        <version>2.2.1</version>
+        <version>1.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>


### PR DESCRIPTION
Before this PR, services with transitive dependencies on spark must constrain conscrypt to version 1.4.1, otherwise they cannot run on Centos:6. Rolling this back in spark should remove the need for consumer services to constrain this package version.